### PR TITLE
EmbedAwareTrait - Check if embed contains iframe

### DIFF
--- a/src/Charcoal/Embed/Mixin/EmbedAwareTrait.php
+++ b/src/Charcoal/Embed/Mixin/EmbedAwareTrait.php
@@ -88,15 +88,18 @@ trait EmbedAwareTrait
         // Fix unencoded ampersands
         $iframe = preg_replace('~&(?!amp;)~i', '&amp;', $iframe);
 
-        // Extract the `src` attribute from embedable iframe.
-        $src = null;
-        $doc = new \DOMDocument();
-        if ($doc->loadHTML($iframe)) {
-            $elems = $doc->getElementsByTagName('iframe');
-            if ($elems->length > 0) {
-                $elem = $elems->item(0);
-                if ($elem->hasAttribute('src')) {
-                    $src = $elem->getAttribute('src');
+        $src = $url;
+
+        if (strpos($iframe, 'iframe') !== false) {
+            // Extract the `src` attribute from embedable iframe.
+            $doc = new \DOMDocument();
+            if ($doc->loadHTML($iframe)) {
+                $elems = $doc->getElementsByTagName('iframe');
+                if ($elems->length > 0) {
+                    $elem = $elems->item(0);
+                    if ($elem->hasAttribute('src')) {
+                        $src = $elem->getAttribute('src');
+                    }
                 }
             }
         }


### PR DESCRIPTION
`DOMDocument()` Is not compatible with HTML5 tags (including `<video>`).

This fix makes sure that the embed code contains an iframe before trying to get the src attribute.

In the event where the embed code does not contain an `iframe` tag (ex. a `video` tag), the embed url will be used as a fallback.